### PR TITLE
Added possibility to create extension methods on builders

### DIFF
--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/CommonBuildersExtensions.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/CommonBuildersExtensions.cs
@@ -1,0 +1,18 @@
+﻿using TextTemplateTransformationFramework.Runtime.CodeGeneration;
+
+namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
+{
+    public class CommonBuildersExtensions : ModelFrameworkCSharpClassBase, ICodeGenerationProvider
+    {
+        public override string Path => "ModelFramework.Common\\Builders";
+
+        public override string DefaultFileName => "Extensions.generated.cs";
+
+        public override bool RecurseOnDeleteGeneratedFiles => false;
+
+        public override object CreateModel()
+            => GetImmutableBuilderExtensionClasses(GetCommonModelTypes(),
+                                                   "ModelFramework.Common",
+                                                   "ModelFramework.Common.Builders");
+    }
+}

--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/ModelFrameworkCSharpClassBase.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/ModelFrameworkCSharpClassBase.cs
@@ -22,7 +22,10 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
         protected override bool EnableNullableContext => true;
         protected override Type RecordCollectionType => typeof(ValueCollection<>);
 
-        protected IClass[] GetCodeStatementBuilderClasses(Type codeStatementType, Type codeStatementInterfaceType, Type codeStatementBuilderInterfaceType, string buildersNamespace)
+        protected IClass[] GetCodeStatementBuilderClasses(Type codeStatementType,
+                                                          Type codeStatementInterfaceType,
+                                                          Type codeStatementBuilderInterfaceType,
+                                                          string buildersNamespace)
             => GetClassesFromSameNamespace(codeStatementType ?? throw new ArgumentNullException(nameof(codeStatementType)))
                 .Select
                 (

--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -60,8 +60,9 @@ namespace ModelFramework.CodeGeneration.Tests
         }
 
         [Fact]
-        public void CanGenerateAll()
+        public void Can_Generate_All_Classes_For_ModelFramework()
         {
+            // Act & Assert
             Verify(GenerateCode.For<CommonBuilders>(Settings));
             Verify(GenerateCode.For<ObjectsBuilders>(Settings));
             Verify(GenerateCode.For<ObjectsCodeStatements>(Settings));
@@ -72,10 +73,30 @@ namespace ModelFramework.CodeGeneration.Tests
             Verify(GenerateCode.For<DatabaseRecords>(Settings));
         }
 
+        [Fact]
+        public void Can_Generate_Builder_Extensions_For_ModelFramework()
+        {
+            // Arrange
+            var settings = new CodeGenerationSettings
+            (
+                basePath: @"C:\Temp\ModelFramework",
+                generateMultipleFiles: false,
+                dryRun: true
+            );
+
+            // Act
+            var generatedCode = GenerateCode.For<CommonBuildersExtensions>(settings);
+            var actual = generatedCode.GenerationEnvironment.ToString();
+
+            // Assert
+            actual.NormalizeLineEndings().Should().NotBeNullOrEmpty().And.NotStartWith("Error:");
+        }
+
         private void Verify(GenerateCode generatedCode)
         {
             if (Settings.DryRun)
             {
+                // Act
                 var actual = generatedCode.GenerationEnvironment.ToString();
 
                 // Assert


### PR DESCRIPTION
Handy when you have builder interfaces with only writable properties (like in QueryFramework)