### PR TITLE
Code generation improvements

### DIFF
--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/ModelFrameworkCSharpClassBase.generated.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/ModelFrameworkCSharpClassBase.generated.cs
@@ -26,7 +26,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
                         @"ModelFramework.Common.Contracts.INameContainer",
@@ -57,7 +57,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
                         @"ModelFramework.Common.Contracts.INameContainer",
@@ -88,7 +88,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Objects.Contracts.ITypeBase",
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
@@ -219,7 +219,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
                         @"ModelFramework.Objects.Contracts.IExtendedVisibilityContainer",
@@ -302,7 +302,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
                         @"ModelFramework.Objects.Contracts.IExtendedVisibilityContainer",
@@ -411,7 +411,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
                         @"ModelFramework.Objects.Contracts.IExtendedVisibilityContainer",
@@ -545,7 +545,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
                         @"ModelFramework.Objects.Contracts.IExtendedVisibilityContainer",
@@ -692,7 +692,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Objects.Contracts.IAttributesContainer",
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
@@ -737,7 +737,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Objects.Contracts.IAttributesContainer",
                         @"ModelFramework.Common.Contracts.INameContainer",
@@ -776,7 +776,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Objects.Contracts.ITypeBase",
                         @"ModelFramework.Common.Contracts.IMetadataContainer",
@@ -858,7 +858,7 @@ namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders
                 new ClassBuilder
                 {
                     Namespace = @"ModelFramework.Objects.Contracts",
-                    Interfaces = new List<System.String>(new[]
+                    Interfaces = new List<string>(new[]
                     {
                         @"ModelFramework.Objects.Contracts.ITypeContainer",
                         @"ModelFramework.Objects.Contracts.IAttributesContainer",

--- a/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CsharpExpressionDumperClassBase.cs
+++ b/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CsharpExpressionDumperClassBase.cs
@@ -37,6 +37,7 @@ public abstract class CSharpExpressionDumperClassBase : ClassBase
             .AddCsharpExpressionDumper
             (
                 x => x.AddSingleton<IObjectHandlerPropertyFilter, SkipDefaultValuesForModelFramework>()
+                      .AddSingleton<ITypeNameFormatter>(new CsharpFriendlyNameFormatter())
                       .AddSingleton<ITypeNameFormatter>(new SkipNamespacesTypeNameFormatter(NamespacesToAbbreviate))
             )
             .BuildServiceProvider();

--- a/src/ModelFramework.CodeGeneration/GlobalUsings.cs
+++ b/src/ModelFramework.CodeGeneration/GlobalUsings.cs
@@ -10,6 +10,7 @@ global using CsharpExpressionDumper.Core.Extensions;
 global using CsharpExpressionDumper.Core.TypeNameFormatters;
 global using Microsoft.Extensions.DependencyInjection;
 global using ModelFramework.CodeGeneration.ObjectHandlerPropertyFilters;
+global using ModelFramework.CodeGeneration.TypeNameFormatters;
 global using ModelFramework.Common.Extensions;
 global using ModelFramework.Generators.Objects;
 global using ModelFramework.Objects.Builders;

--- a/src/ModelFramework.CodeGeneration/ModelFramework.CodeGeneration.csproj
+++ b/src/ModelFramework.CodeGeneration/ModelFramework.CodeGeneration.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsharpExpressionDumper.Core" Version="1.3.0" />
+    <PackageReference Include="CsharpExpressionDumper.Core" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/ModelFramework.CodeGeneration/TypeNameFormatters/CsharpFriendlyNameFormatter.cs
+++ b/src/ModelFramework.CodeGeneration/TypeNameFormatters/CsharpFriendlyNameFormatter.cs
@@ -1,0 +1,7 @@
+﻿namespace ModelFramework.CodeGeneration.TypeNameFormatters;
+
+public class CsharpFriendlyNameFormatter : ITypeNameFormatter
+{
+    public string? Format(string currentValue)
+        => currentValue.GetCsharpFriendlyTypeName();
+}

--- a/src/ModelFramework.Common.Tests/Extensions/StringExtensionsTests.cs
+++ b/src/ModelFramework.Common.Tests/Extensions/StringExtensionsTests.cs
@@ -159,4 +159,41 @@ public class StringExtensionsTests
         // Assert
         actual.Should().Be(expectedResult);
     }
+
+    [Theory]
+    [InlineData("SomeUnknownType", "SomeUnknownType")]
+    [InlineData("", "")]
+    [InlineData(" ", " ")]
+    [InlineData("    ", "    ")]
+    [InlineData("System.Char", "char")]
+    [InlineData("System.Char with some prefix", "System.Char with some prefix")]
+    [InlineData("suffix System.Char", "suffix System.Char")]
+    [InlineData("System.String", "string")]
+    [InlineData("System.Boolean", "bool")]
+    [InlineData("System.Object", "object")]
+    [InlineData("System.Decimal", "decimal")]
+    [InlineData("System.Double", "double")]
+    [InlineData("System.Single", "float")]
+    [InlineData("System.Byte", "byte")]
+    [InlineData("System.SByte", "sbyte")]
+    [InlineData("System.Int16", "short")]
+    [InlineData("System.UInt16", "ushort")]
+    [InlineData("System.Int32", "int")]
+    [InlineData("System.UInt32", "uint")]
+    [InlineData("System.Int64", "long")]
+    [InlineData("System.UInt64", "ulong")]
+    [InlineData("System.String[]", "string[]")]
+    [InlineData("IEnumerable<System.String>", "IEnumerable<string>")]
+    [InlineData("KeyValuePair<System.String, System.String>", "KeyValuePair<string, string>")]
+    [InlineData("KeyValuePair<System.String,System.String>", "KeyValuePair<string,string>")]
+    [InlineData("TripleGeneric<System.String, System.String, System.String>", "TripleGeneric<string, string, string>")]
+    [InlineData("TripleGeneric<System.String,System.String,System.String>", "TripleGeneric<string,string,string>")]
+    public void GetCsharpFriendlyTypeName_Returns_Correct_Result(string input, string expectedResult)
+    {
+        // Act
+        var actual = input.GetCsharpFriendlyTypeName();
+
+        // Assert
+        actual.Should().Be(expectedResult);
+    }
 }

--- a/src/ModelFramework.Common/Extensions/StringExtensions.cs
+++ b/src/ModelFramework.Common/Extensions/StringExtensions.cs
@@ -64,29 +64,48 @@ public static class StringExtensions
     }
 
     public static string GetCsharpFriendlyTypeName(this string instance)
-    {
-        if (string.IsNullOrEmpty(instance))
+        => instance switch
         {
-            return instance;
-        }
+            "System.Char" => "char",
+            "System.String" => "string",
+            "System.Boolean" => "bool",
+            "System.Object" => "object",
+            "System.Decimal" => "decimal",
+            "System.Double" => "double",
+            "System.Single" => "float",
+            "System.Byte" => "byte",
+            "System.SByte" => "sbyte",
+            "System.Int16" => "short",
+            "System.UInt16" => "ushort",
+            "System.Int32" => "int",
+            "System.UInt32" => "uint",
+            "System.Int64" => "long",
+            "System.UInt64" => "ulong",
+            _ => instance
+                .ReplaceGenericArgument("System.Char", "char")
+                .ReplaceGenericArgument("System.String", "string")
+                .ReplaceGenericArgument("System.Boolean", "bool")
+                .ReplaceGenericArgument("System.Object", "object")
+                .ReplaceGenericArgument("System.Decimal", "decimal")
+                .ReplaceGenericArgument("System.Double", "double")
+                .ReplaceGenericArgument("System.Single", "float")
+                .ReplaceGenericArgument("System.Byte", "byte")
+                .ReplaceGenericArgument("System.SByte", "sbyte")
+                .ReplaceGenericArgument("System.Int16", "short")
+                .ReplaceGenericArgument("System.UInt16", "ushort")
+                .ReplaceGenericArgument("System.Int32", "int")
+                .ReplaceGenericArgument("System.UInt32", "uint")
+                .ReplaceGenericArgument("System.Int64", "long")
+                .ReplaceGenericArgument("System.UInt64", "ulong")
+        };
 
-        return instance
-            .Replace("System.Char", "char")
-            .Replace("System.String", "string")
-            .Replace("System.Boolean", "bool")
-            .Replace("System.Object", "object")
-            .Replace("System.Decimal", "decimal")
-            .Replace("System.Double", "double")
-            .Replace("System.Single", "float")
-            .Replace("System.Byte", "byte")
-            .Replace("System.SByte", "sbyte")
-            .Replace("System.Int16", "short")
-            .Replace("System.UInt16", "ushort")
-            .Replace("System.Int32", "int")
-            .Replace("System.UInt32", "uint")
-            .Replace("System.Int64", "long")
-            .Replace("System.UInt64", "ulong");
-    }
+    private static string ReplaceGenericArgument(this string instance, string find, string replace)
+        => instance
+            .Replace($"<{find}", $"<{replace}")
+            .Replace($"{find}>", $"{replace}>")
+            .Replace($",{find}", $",{replace}")
+            .Replace($", {find}", $", {replace}")
+            .Replace($"{find}[]", $"{replace}[]");
 
     public static string GetCsharpFriendlyName(this string instance)
         => _keywords.Contains(instance)

--- a/src/ModelFramework.Generators.Database/ModelFramework.Generators.Database.csproj
+++ b/src/ModelFramework.Generators.Database/ModelFramework.Generators.Database.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\ModelFramework.Generators.Shared\ModelFramework.Generators.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Templates\ChildTemplates\SqlStatements\" />
+  </ItemGroup>
+
 </Project>

--- a/src/ModelFramework.Generators.Database/SqlServerDatabaseSchemaGenerator.generated.cs
+++ b/src/ModelFramework.Generators.Database/SqlServerDatabaseSchemaGenerator.generated.cs
@@ -15,7 +15,6 @@ namespace ModelFramework.Generators.Database
     using ModelFramework.Common.Extensions;
     using ModelFramework.Database.Contracts;
     using ModelFramework.Database.Extensions;
-    using ModelFramework.Database.SqlStatements;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -107,7 +106,6 @@ namespace ModelFramework.Generators.Database
             RegisterChildTemplate(@"SqlServerDatabaseSchemaGenerator.DefaultViewSelectFieldsTemplate", () => new SqlServerDatabaseSchemaGenerator_DefaultViewSelectFieldsTemplate(), typeof(IView));
             RegisterChildTemplate(@"SqlServerDatabaseSchemaGenerator.DefaultViewSourceTemplate", () => new SqlServerDatabaseSchemaGenerator_DefaultViewSourceTemplate(), typeof(IViewSource));
             RegisterChildTemplate(@"SqlServerDatabaseSchemaGenerator.DefaultViewSourcesTemplate", () => new SqlServerDatabaseSchemaGenerator_DefaultViewSourcesTemplate(), typeof(IView));
-            RegisterChildTemplate(@"SqlServerDatabaseSchemaGenerator.DefaultLiteralSqlStatementTemplate", () => new SqlServerDatabaseSchemaGenerator_DefaultLiteralSqlStatementTemplate(), typeof(LiteralSqlStatement));
             RegisterViewModel(@"SqlServerDatabaseSchemaGenerator.DefaultDefaultValueConstraintViewModel", () => new SqlServerDatabaseSchemaGenerator_DefaultDefaultValueConstraintViewModel(), typeof(IDefaultValueConstraint));
             bool createCodeGenerationHeaderValueAcquired = false;
             if (this.Session != null && this.Session.ContainsKey("CreateCodeGenerationHeader") && this.Session["CreateCodeGenerationHeader"] != null)
@@ -1170,7 +1168,7 @@ BEGIN"));
             RootTemplate.PushIndent("    ");
 
             
-            RenderChildTemplate(null, Model.Statements, null, false, null, null, new CustomDelegates { });
+            RenderChildTemplate(null, Model.Statements, null, false, null, null, new CustomDelegates { ResolverDelegate = ResolveFromMetadata, RenderChildTemplateDelegate = RenderModel, });
 
             RootTemplate.PopIndent();
 
@@ -2062,52 +2060,6 @@ AS
         }
 
         public IView Model { get; set; }
-
-    }
-    [System.CodeDom.Compiler.GeneratedCodeAttribute(@"T4PlusCSharpCodeGenerator", @"1.0.0.0")]
-    public class SqlServerDatabaseSchemaGenerator_DefaultLiteralSqlStatementTemplate : SqlServerDatabaseSchemaGeneratorBaseChild
-    {
-        public virtual void Render(global::System.Text.StringBuilder builder)
-        {
-            var backup = this.GenerationEnvironment;
-            if (builder != null) this.GenerationEnvironment = builder;
-            WriteLine(Model.Statement);
-
-
-            if (builder != null) this.GenerationEnvironment = backup;
-        }
-
-
-        public virtual void Initialize(global::System.Action additionalActionDelegate = null)
-        {
-            this.Errors.Clear();
-            this.GenerationEnvironment.Clear();
-            if (Session == null)
-            {
-                Session = new global::System.Collections.Generic.Dictionary<string, object>();
-            }
-            if (RootTemplate != null)
-            {
-                ChildTemplates = RootTemplate.ChildTemplates;
-                ViewModels = RootTemplate.ViewModels;
-            }
-            else
-            {
-                ChildTemplates.Clear();
-                ViewModels.Clear();
-            }
-            if (RootTemplate != null)
-            {
-                PlaceholderChildrenDictionary = RootTemplate.PlaceholderChildrenDictionary;
-            }
-            else
-            {
-                PlaceholderChildrenDictionary.Clear();
-            }
-
-        }
-
-        public LiteralSqlStatement Model { get; set; }
 
     }
     [System.CodeDom.Compiler.GeneratedCodeAttribute(@"T4PlusCSharpCodeGenerator", @"1.0.0.0")]

--- a/src/ModelFramework.Generators.Database/Templates/ChildTemplates/SqlStatements/LiteralSqlStatement.Default.template
+++ b/src/ModelFramework.Generators.Database/Templates/ChildTemplates/SqlStatements/LiteralSqlStatement.Default.template
@@ -1,4 +1,0 @@
-﻿<#@ template language="c#" #>
-<#@ templateName value="SqlServerDatabaseSchemaGenerator.DefaultLiteralSqlStatementTemplate" #>
-<#@ model type="LiteralSqlStatement" #>
-<# WriteLine(Model.Statement); #>

--- a/src/ModelFramework.Generators.Database/Templates/ChildTemplates/StoredProcedure.Default.template
+++ b/src/ModelFramework.Generators.Database/Templates/ChildTemplates/StoredProcedure.Default.template
@@ -14,6 +14,6 @@ GO
 CREATE PROCEDURE [<#= schemaEntity.Name.FormatAsDatabaseIdentifier() #>].[<#= Model.Name.FormatAsDatabaseIdentifier() #>]
 <#@ renderChildTemplate name="SqlServerDatabaseSchemaGenerator.DefaultStoredProcedureParameterTemplate" model="Model.Parameters" customResolverDelegate="ResolveFromMetadata" #>
 AS
-BEGIN<# WriteLine(""); if (Model.Statements.Any()) { #><# RootTemplate.PushIndent("    "); #><#@ renderChildTemplate model="Model.Statements" #><# RootTemplate.PopIndent(); #>
+BEGIN<# WriteLine(""); if (Model.Statements.Any()) { #><# RootTemplate.PushIndent("    "); #><#@ renderChildTemplate model="Model.Statements" customResolverDelegate="ResolveFromMetadata" customRenderChildTemplateDelegate="RenderModel" #><# RootTemplate.PopIndent(); #>
 <# } #>END
 GO

--- a/src/ModelFramework.Generators.Database/Templates/SqlServerDatabaseSchemaGenerator.template
+++ b/src/ModelFramework.Generators.Database/Templates/SqlServerDatabaseSchemaGenerator.template
@@ -7,6 +7,5 @@
 <#@ registerViewModels path="$(BasePath)ModelFramework.Generators.Database\Templates\ChildTemplates" searchPattern="*.viewmodel" #>
 <#@ import namespace="ModelFramework.Database.Contracts" #>
 <#@ import namespace="ModelFramework.Database.Extensions" #>
-<#@ import namespace="ModelFramework.Database.SqlStatements" #>
 <#@ model type="System.Collections.Generic.IEnumerable`1" genericTypeParameter="ModelFramework.Database.Contracts.ISchema" #>
 <#@ renderChildTemplate name="SqlServerDatabaseSchemaGenerator.DefaultSchemaTemplate" model="Model" customResolverDelegate="ResolveFromMetadata" #>

--- a/src/ModelFramework.Generators.Objects.Tests/CSharpClassGenerator_DefaultMethodTemplateClassTests.cs
+++ b/src/ModelFramework.Generators.Objects.Tests/CSharpClassGenerator_DefaultMethodTemplateClassTests.cs
@@ -339,8 +339,12 @@ public class Method_DefaultClassTests
             .WithType(typeof(string))
             .AddCodeStatements(new LiteralCodeStatementBuilder().WithStatement("throw new NotImplementedException();"))
             .Build();
-        var sut = TemplateRenderHelper.CreateNestedTemplate<CSharpClassGenerator, CSharpClassGenerator_DefaultMethodTemplate>(model, rootModel);
-        sut.RootTemplate.RegisterChildTemplate("Test", () => new CustomStatementTemplate(), typeof(LiteralCodeStatement));
+        var sut = TemplateRenderHelper.CreateNestedTemplate<CSharpClassGenerator, CSharpClassGenerator_DefaultMethodTemplate>
+        (
+            model,
+            rootModel,
+            rootAdditionalActionDelegate: rootTemplate => rootTemplate.RegisterChildTemplate("Test", () => new CustomStatementTemplate(), typeof(LiteralCodeStatement))
+        );
 
         // Act
         var actual = TemplateRenderHelper.GetTemplateOutput(sut, model);

--- a/src/ModelFramework.Generators.Objects/CSharpClassGenerator.generated.cs
+++ b/src/ModelFramework.Generators.Objects/CSharpClassGenerator.generated.cs
@@ -13,7 +13,6 @@ namespace ModelFramework.Generators.Objects
     using ModelFramework.Common;
     using ModelFramework.Common.Contracts;
     using ModelFramework.Common.Extensions;
-    using ModelFramework.Objects.CodeStatements;
     using ModelFramework.Objects.Contracts;
     using ModelFramework.Objects.Extensions;
     using ModelFramework.Objects.Settings;
@@ -223,7 +222,6 @@ namespace ModelFramework.Generators.Objects
             RegisterChildTemplate(@"CSharpClassGenerator.DefaultPropertySetterBodyTemplate", () => new CSharpClassGenerator_DefaultPropertySetterBodyTemplate(), typeof(IClassProperty));
             RegisterChildTemplate(@"CSharpClassGenerator.DefaultPropertyTemplate", () => new CSharpClassGenerator_DefaultPropertyTemplate(), typeof(IClassProperty));
             RegisterChildTemplate(@"CSharpClassGenerator.DefaultUsingsTemplate", () => new CSharpClassGenerator_DefaultUsingsTemplate(), typeof(IEnumerable<ITypeBase>));
-            RegisterChildTemplate(@"CSharpClassGenerator.DefaultLiteralCodeStatementTemplate", () => new CSharpClassGenerator_DefaultLiteralCodeStatementTemplate(), typeof(LiteralCodeStatement));
             RegisterViewModel(@"CSharpClassGenerator.ViewModel", () => new CSharpClassGenerator_ViewModel(), typeof(System.Collections.Generic.IEnumerable<ModelFramework.Objects.Contracts.ITypeBase>));
             RegisterViewModel(@"CSharpClassGenerator.DefaultAttributeViewModel", () => new CSharpClassGenerator_DefaultAttributeViewModel(), typeof(IAttribute));
             RegisterViewModel(@"CSharpClassGenerator.DefaultParameterAttributeViewModel", () => new CSharpClassGenerator_DefaultParameterAttributeViewModel(), typeof(IAttribute));
@@ -952,7 +950,7 @@ namespace ModelFramework.Generators.Objects
             RootTemplate.PushIndent("            ");
 
             
-            RenderChildTemplate(null, Model.CodeStatements, null, false, null, null, new CustomDelegates { });
+            RenderChildTemplate(null, Model.CodeStatements, null, false, null, null, new CustomDelegates { ResolverDelegate = ResolveFromMetadata, RenderChildTemplateDelegate = RenderModel, });
 
             RootTemplate.PopIndent();
 
@@ -1262,7 +1260,7 @@ namespace ModelFramework.Generators.Objects
             RootTemplate.PushIndent("            ");
 
             
-            RenderChildTemplate(null, Model.CodeStatements, null, false, null, null, new CustomDelegates { });
+            RenderChildTemplate(null, Model.CodeStatements, null, false, null, null, new CustomDelegates { ResolverDelegate = ResolveFromMetadata, RenderChildTemplateDelegate = RenderModel, });
 
             RootTemplate.PopIndent();
 
@@ -1475,7 +1473,7 @@ namespace ModelFramework.Generators.Objects
             RootTemplate.PushIndent("                ");
 
             
-            RenderChildTemplate(null, Model.GetterCodeStatements, null, false, null, null, new CustomDelegates { });
+            RenderChildTemplate(null, Model.GetterCodeStatements, null, false, null, null, new CustomDelegates { ResolverDelegate = ResolveFromMetadata, RenderChildTemplateDelegate = RenderModel, });
 
             RootTemplate.PopIndent();
 
@@ -1545,7 +1543,7 @@ namespace ModelFramework.Generators.Objects
             RootTemplate.PushIndent("                ");
 
             
-            RenderChildTemplate(null, Model.InitializerCodeStatements, null, false, null, null, new CustomDelegates { });
+            RenderChildTemplate(null, Model.InitializerCodeStatements, null, false, null, null, new CustomDelegates { ResolverDelegate = ResolveFromMetadata, RenderChildTemplateDelegate = RenderModel, });
 
             RootTemplate.PopIndent();
 
@@ -1615,7 +1613,7 @@ namespace ModelFramework.Generators.Objects
             RootTemplate.PushIndent("                ");
 
             
-            RenderChildTemplate(null, Model.SetterCodeStatements, null, false, null, null, new CustomDelegates { });
+            RenderChildTemplate(null, Model.SetterCodeStatements, null, false, null, null, new CustomDelegates { ResolverDelegate = ResolveFromMetadata, RenderChildTemplateDelegate = RenderModel, });
 
             RootTemplate.PopIndent();
 
@@ -1841,52 +1839,6 @@ namespace ModelFramework.Generators.Objects
         }
 
         public IEnumerable<ITypeBase> Model { get; set; }
-
-    }
-    [System.CodeDom.Compiler.GeneratedCodeAttribute(@"T4PlusCSharpCodeGenerator", @"1.0.0.0")]
-    public class CSharpClassGenerator_DefaultLiteralCodeStatementTemplate : CSharpClassGeneratorBaseChild
-    {
-        public virtual void Render(global::System.Text.StringBuilder builder)
-        {
-            var backup = this.GenerationEnvironment;
-            if (builder != null) this.GenerationEnvironment = builder;
-            WriteLine(Model.Statement);
-
-
-            if (builder != null) this.GenerationEnvironment = backup;
-        }
-
-
-        public virtual void Initialize(global::System.Action additionalActionDelegate = null)
-        {
-            this.Errors.Clear();
-            this.GenerationEnvironment.Clear();
-            if (Session == null)
-            {
-                Session = new global::System.Collections.Generic.Dictionary<string, object>();
-            }
-            if (RootTemplate != null)
-            {
-                ChildTemplates = RootTemplate.ChildTemplates;
-                ViewModels = RootTemplate.ViewModels;
-            }
-            else
-            {
-                ChildTemplates.Clear();
-                ViewModels.Clear();
-            }
-            if (RootTemplate != null)
-            {
-                PlaceholderChildrenDictionary = RootTemplate.PlaceholderChildrenDictionary;
-            }
-            else
-            {
-                PlaceholderChildrenDictionary.Clear();
-            }
-
-        }
-
-        public LiteralCodeStatement Model { get; set; }
 
     }
     [System.CodeDom.Compiler.GeneratedCodeAttribute(@"T4PlusCSharpCodeGenerator", @"1.0.0.0")]

--- a/src/ModelFramework.Generators.Objects/Templates/CSharpClassGenerator.template
+++ b/src/ModelFramework.Generators.Objects/Templates/CSharpClassGenerator.template
@@ -6,7 +6,6 @@
 <#@ registerChildTemplates path="$(BasePath)ModelFramework.Generators.Objects\Templates\ChildTemplates" searchPattern="*.template" recurse="true" #>
 <#@ registerViewModels path="$(BasePath)ModelFramework.Generators.Objects\Templates" searchPattern="*.viewmodel" recurse="true" #>
 <#@ import namespace="ModelFramework.Objects.Contracts" #>
-<#@ import namespace="ModelFramework.Objects.CodeStatements" #>
 <#@ import namespace="ModelFramework.Objects.Extensions" #>
 <#@ import namespace="ModelFramework.Objects.Settings" #>
 <#@ model type="System.Collections.Generic.IEnumerable`1" genericTypeParameter="ModelFramework.Objects.Contracts.ITypeBase" #>

--- a/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/CodeStatements/LiteralCodeStatement.Default.template
+++ b/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/CodeStatements/LiteralCodeStatement.Default.template
@@ -1,4 +1,0 @@
-﻿<#@ template language="c#" #>
-<#@ templateName value="CSharpClassGenerator.DefaultLiteralCodeStatementTemplate" #>
-<#@ model type="LiteralCodeStatement" #>
-<# WriteLine(Model.Statement); #>

--- a/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Ctor.Default.template
+++ b/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Ctor.Default.template
@@ -5,6 +5,6 @@
 <#@ renderChildTemplate name="CSharpClassGenerator.DefaultAttributeTemplate" model="Model.Attributes" customResolverDelegate="ResolveFromMetadata" #>
         <#= Model.GetModifiers() #><#= ViewModel.Name #>(<#@ renderChildTemplate name="CSharpClassGenerator.DefaultParameterTemplate" model="Model.Parameters" separatorTemplateName="CommaAndSpace" customResolverDelegate="ResolveFromMetadata" #>)<# if (ViewModel.ShouldRenderChainCall) { #>: <#= Model.ChainCall #><# } #><# if (ViewModel.OmitCode) { #>;<# } else { #>
 
-        {<# WriteLine(""); if (ViewModel.ShouldRenderCodeStatements) { #><# RootTemplate.PushIndent("            "); #><#@ renderChildTemplate model="Model.CodeStatements" #><# RootTemplate.PopIndent(); #>
+        {<# WriteLine(""); if (ViewModel.ShouldRenderCodeStatements) { #><# RootTemplate.PushIndent("            "); #><#@ renderChildTemplate model="Model.CodeStatements" customResolverDelegate="ResolveFromMetadata" customRenderChildTemplateDelegate="RenderModel" #><# RootTemplate.PopIndent(); #>
 <# } #>        }<# } #>
 

--- a/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Method.Default.template
+++ b/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Method.Default.template
@@ -5,6 +5,6 @@
 <#@ renderChildTemplate name="CSharpClassGenerator.DefaultAttributeTemplate" model="Model.Attributes" customResolverDelegate="ResolveFromMetadata" #>
         <# if (ViewModel.ShouldRenderModifiers) { #><#= Model.GetModifiers() #><# } #><#= ViewModel.ReturnTypeName #> <# if (ViewModel.ShouldRenderExplicitInterfaceName) { #><#= Model.ExplicitInterfaceName #>.<# } #><#= ViewModel.Name #><#= Model.GetGenericTypeArgumentsString() #>(<# if (Model.ExtensionMethod) { #>this <# } #><#@ renderChildTemplate name="CSharpClassGenerator.DefaultParameterTemplate" model="Model.Parameters" separatorTemplateName="CommaAndSpace" customResolverDelegate="ResolveFromMetadata" #>)<#= Model.GetGenericTypeArgumentConstraintsString() #><# if (ViewModel.OmitCode) { #>;<# } else { #>
 
-        {<# WriteLine("");if (ViewModel.ShouldRenderCodeStatements) { #><# RootTemplate.PushIndent("            "); #><#@ renderChildTemplate model="Model.CodeStatements" #><# RootTemplate.PopIndent(); #>
+        {<# WriteLine("");if (ViewModel.ShouldRenderCodeStatements) { #><# RootTemplate.PushIndent("            "); #><#@ renderChildTemplate model="Model.CodeStatements" customResolverDelegate="ResolveFromMetadata" customRenderChildTemplateDelegate="RenderModel" #><# RootTemplate.PopIndent(); #>
 <# } #>        }<# } #>
 

--- a/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Property.Default.GetterBody.template
+++ b/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Property.Default.GetterBody.template
@@ -8,6 +8,6 @@ get;
    else
    { #>
 get
-            {<# WriteLine(""); if (Model.GetterCodeStatements.Any()) { #><# RootTemplate.PushIndent("                "); #><#@ renderChildTemplate model="Model.GetterCodeStatements" #><# RootTemplate.PopIndent(); #><# } #>
+            {<# WriteLine(""); if (Model.GetterCodeStatements.Any()) { #><# RootTemplate.PushIndent("                "); #><#@ renderChildTemplate model="Model.GetterCodeStatements" customResolverDelegate="ResolveFromMetadata" customRenderChildTemplateDelegate="RenderModel" #><# RootTemplate.PopIndent(); #><# } #>
             }
 <# } #>

--- a/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Property.Default.InitializerBody.template
+++ b/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Property.Default.InitializerBody.template
@@ -8,6 +8,6 @@ init;
    else
    { #>
 init
-            {<# WriteLine(""); if (Model.InitializerCodeStatements.Any()) { #><# RootTemplate.PushIndent("                "); #><#@ renderChildTemplate model="Model.InitializerCodeStatements" #><# RootTemplate.PopIndent(); #><# } #>
+            {<# WriteLine(""); if (Model.InitializerCodeStatements.Any()) { #><# RootTemplate.PushIndent("                "); #><#@ renderChildTemplate model="Model.InitializerCodeStatements" customResolverDelegate="ResolveFromMetadata" customRenderChildTemplateDelegate="RenderModel" #><# RootTemplate.PopIndent(); #><# } #>
             }
 <# } #>

--- a/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Property.Default.SetterBody.template
+++ b/src/ModelFramework.Generators.Objects/Templates/ChildTemplates/Property.Default.SetterBody.template
@@ -8,6 +8,6 @@ set;
    else
    { #>
 set
-            {<# WriteLine(""); if (Model.SetterCodeStatements.Any()) { #><# RootTemplate.PushIndent("                "); #><#@ renderChildTemplate model="Model.SetterCodeStatements" #><# RootTemplate.PopIndent(); #><# } #>
+            {<# WriteLine(""); if (Model.SetterCodeStatements.Any()) { #><# RootTemplate.PushIndent("                "); #><#@ renderChildTemplate model="Model.SetterCodeStatements" customResolverDelegate="ResolveFromMetadata" customRenderChildTemplateDelegate="RenderModel" #><# RootTemplate.PopIndent(); #><# } #>
             }
 <# } #>

--- a/src/ModelFramework.Generators.Shared/ModelFramework.Generators.Shared.csproj
+++ b/src/ModelFramework.Generators.Shared/ModelFramework.Generators.Shared.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="pauldeen79.TextTemplateTransformationFramework.Runtime" Version="0.1.13" />
+    <PackageReference Include="pauldeen79.TextTemplateTransformationFramework.Runtime" Version="0.1.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ModelFramework.Generators.Shared/ModelFrameworkGenerator.cs
+++ b/src/ModelFramework.Generators.Shared/ModelFrameworkGenerator.cs
@@ -139,6 +139,40 @@ namespace ModelFramework.Generators.Shared
             base.RenderTemplate(template, model, iterationNumber, iterationCount, resolveTemplateName);
         }
 
+        protected void RenderModel(string templateName, object template, object item, bool renderAsEnumerable, bool silentlyContinueOnError, int? iterationNumber, int? iterationCount)
+        {
+            var templates = template as IEnumerable<object>;
+            if (templates == null)
+            {
+                // Template is known, so use default rendering.
+                RenderChildTemplate(templateName, item, renderAsEnumerable, silentlyContinueOnError);
+                return;
+            }
+
+            var count = templates.Count();
+            if (count == 1)
+            {
+                //TODO: Review if this path is reachable
+                // Template is known, so use default rendering.
+                RenderChildTemplate(templateName, item, renderAsEnumerable, silentlyContinueOnError);
+            }
+            else if (count > 1)
+            {
+                //TODO: Review if this path is reachable
+                if (!silentlyContinueOnError)
+                {
+                    Error("RenderModel error: Multiple templates found!");
+                }
+            }
+            else
+            {
+                // Template is unknown, so use ToString on the model.
+                // Note that by using this, the model is tightly coupled with the generator!
+                Write(ToStringHelper.ToStringWithCulture(item));
+                WriteLine("");
+            }
+        }
+
 
     }
     #endregion

--- a/src/ModelFramework.Generators.Shared/Templates/Includes/RenderOverrides.ttinclude
+++ b/src/ModelFramework.Generators.Shared/Templates/Includes/RenderOverrides.ttinclude
@@ -39,4 +39,38 @@
             }
             base.RenderTemplate(template, model, iterationNumber, iterationCount, resolveTemplateName);
         }
+
+        protected void RenderModel(string templateName, object template, object item, bool renderAsEnumerable, bool silentlyContinueOnError, int? iterationNumber, int? iterationCount)
+        {
+            var templates = template as IEnumerable<object>;
+            if (templates == null)
+            {
+                // Template is known, so use default rendering.
+                RenderChildTemplate(templateName, item, renderAsEnumerable, silentlyContinueOnError);
+                return;
+            }
+
+            var count = templates.Count();
+            if (count == 1)
+            {
+                //TODO: Review if this path is reachable
+                // Template is known, so use default rendering.
+                RenderChildTemplate(templateName, item, renderAsEnumerable, silentlyContinueOnError);
+            }
+            else if (count > 1)
+            {
+                //TODO: Review if this path is reachable
+                if (!silentlyContinueOnError)
+                {
+                    Error("RenderModel error: Multiple templates found!");
+                }
+            }
+            else
+            {
+                // Template is unknown, so use ToString on the model.
+                // Note that by using this, the model is tightly coupled with the generator!
+                Write(ToStringHelper.ToStringWithCulture(item));
+                WriteLine("");
+            }
+        }
 #>


### PR DESCRIPTION
- Fixed GetCsharpFriendlyTypeName extension method
- Implemented TypeNameFormatter that produces C# keywords (GetCsharpFriendlyTypeNames) of known types
- Fixed open/closed issue on C# and SQL code generators for code statements, and added support for both injected templates (using metadata) and direct model rendering (ToString on model, when no template has been found)
- Upgraded to latest version of TextTemplateTransformationFramework.Runtime, allowing easier custom template registrations on CreateNestedTemplate and CreateNestedTemplateContext methods in TemplateHelper class