### PR TITLE
GetImmutableBuilderExtensionClasses improvement

### DIFF
--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/CommonBuildersExtensions.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/CommonBuildersExtensions.cs
@@ -11,5 +11,6 @@ public class CommonBuildersExtensions : ModelFrameworkCSharpClassBase
     public override object CreateModel()
         => GetImmutableBuilderExtensionClasses(GetCommonModelTypes(),
                                                "ModelFramework.Common",
-                                               "ModelFramework.Common.Builders");
+                                               "ModelFramework.Common.Extensions",
+                                               "ModelFramework.Common.Contracts.Builders");
 }


### PR DESCRIPTION
Added new feature to GetImmutableBuilderExtensionClasses method: extension methods now use generics and interfaces

This reduces the amount of code needed to generate extension methods in immutable builder interfaces. (and the only scenario you might want this, is when your builders use interfaces)