### PR TITLE
Added support to immutable class builder for backing members of collection properties

### DIFF
--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/TestCSharpClassBaseWithoutInheritance.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/TestCSharpClassBaseWithoutInheritance.cs
@@ -1,9 +1,13 @@
-﻿namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders;
+﻿using ModelFramework.Common.Builders;
+
+namespace ModelFramework.CodeGeneration.Tests.CodeGenerationProviders;
 
 public abstract partial class TestCSharpClassBaseWithoutInheritance : ModelFrameworkCSharpClassBase
 {
     protected override bool InheritFromInterfaces => false;
     protected override bool AddNullChecks => true; // this enables null checks in c'tor of both records and builders
+    protected override bool CopyPropertyCode => false; // this skips property code on the immutable builders
+    protected override bool CopyFields => false; // this skips fields on the immutable builders
 
     protected override AttributeBuilder AttributeInitializeDelegate(Attribute sourceAttribute)
     {
@@ -58,14 +62,14 @@ public abstract partial class TestCSharpClassBaseWithoutInheritance : ModelFrame
         else if (typeName.Contains("Collection<ModelFramework.", StringComparison.InvariantCulture))
         {
             property.WithTypeName(typeName.Replace("Test.Contracts.I", "Test.", StringComparison.InvariantCulture));
+            property.AddCollectionBackingFieldOnImmutableClass(typeof(ValueCollection<>));
             property.ConvertCollectionPropertyToBuilderOnBuilder
             (
                 addNullChecks: false, // already checked in constructor by using the AddNullChecks property, see above in this class
-                collectionType: typeof(ReadOnlyValueCollection<>).WithoutGenerics(),
+                collectionType: typeof(ValueCollection<>).WithoutGenerics(),
                 argumentType: null, // using builders namespace instead
                 buildersNamespace: "ModelFramework.Common.Tests.Test.Builders",
                 builderCollectionTypeName: typeof(IEnumerable<>).WithoutGenerics()
-
             );
         }
         else if (typeName.IsStringTypeName())

--- a/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
+++ b/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
@@ -15,6 +15,7 @@ public abstract class CSharpClassBase : ClassBase
     protected virtual bool InheritFromInterfaces => true;
     protected virtual bool AddPrivateSetters => false;
     protected virtual bool CopyPropertyCode => true;
+    protected virtual bool CopyFields => true;
     protected virtual bool EnableEntityInheritance => false;
     protected virtual bool EnableBuilderInhericance => false;
     protected virtual bool RemoveDuplicateWithMethods => true;
@@ -328,6 +329,7 @@ public abstract class CSharpClassBase : ClassBase
             generationSettings: new(
                 useLazyInitialization: UseLazyInitialization,
                 copyPropertyCode: CopyPropertyCode,
+                copyFields: CopyFields,
                 allowGenerationWithoutProperties: AllowGenerationWithoutProperties),
             inheritanceSettings: new(
                 enableEntityInheritance: EnableEntityInheritance,

--- a/src/ModelFramework.Common.Tests/Test/Parent.generated.cs
+++ b/src/ModelFramework.Common.Tests/Test/Parent.generated.cs
@@ -30,7 +30,10 @@ namespace ModelFramework.Common.Tests.Test
 
         public System.Collections.Generic.IReadOnlyCollection<ModelFramework.Common.Tests.Test.Child> Children
         {
-            get;
+            get
+            {
+                return _children;
+            }
         }
 
         public System.Collections.Generic.IReadOnlyCollection<string> Strings
@@ -46,10 +49,12 @@ namespace ModelFramework.Common.Tests.Test
             if (strings == null) throw new System.ArgumentNullException("strings");
             this.ParentProperty = parentProperty;
             this.Child = child;
-            this.Children = new CrossCutting.Common.ReadOnlyValueCollection<ModelFramework.Common.Tests.Test.Child>(children);
-            this.Strings = new List<System.String>(strings);
+            _children = new CrossCutting.Common.ValueCollection<ModelFramework.Common.Tests.Test.Child>(children);
+            this.Strings = new System.Collections.Generic.List<System.String>(strings);
             System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
         }
+
+        private CrossCutting.Common.ValueCollection<ModelFramework.Common.Tests.Test.Child> _children;
     }
 #nullable restore
 }

--- a/src/ModelFramework.Common/Extensions/EnumerableOfMetadataExtensions.cs
+++ b/src/ModelFramework.Common/Extensions/EnumerableOfMetadataExtensions.cs
@@ -36,6 +36,16 @@ public static class EnumerableOfMetadataExtensions
             .Select(md => md.Value)
             .OfType<T>();
 
+    public static IEnumerable<T> WhenEmpty<T>(this IEnumerable<T> instance, IEnumerable<T> whenEmpty)
+        => instance.Any()
+            ? instance
+            : whenEmpty;
+
+    public static IEnumerable<T> WhenEmpty<T>(this IEnumerable<T> instance, Func<IEnumerable<T>> whenEmpty)
+        => instance.Any()
+            ? instance
+            : whenEmpty();
+
     private static T CreateMetadata<T>(IMetadata metadataItem, Func<T> defaultValueDelegate)
     {
         if (metadataItem.Value is T t)

--- a/src/ModelFramework.Objects/Builders/ClassPropertyBuilder.cs
+++ b/src/ModelFramework.Objects/Builders/ClassPropertyBuilder.cs
@@ -98,6 +98,15 @@ public partial class ClassPropertyBuilder
           .AddMetadata(MetadataNames.CustomBuilderMethodParameterExpression, customBuilderMethodParameterExpression.WhenNullOrEmpty("{0}.Select(x => x.Build())"))
           .AddMetadata(MetadataNames.CustomBuilderConstructorInitializeExpression, customBuilderConstructorInitializeExpression.WhenNullOrEmpty(() => CreateDefaultCustomBuilderConstructorCollectionPropertyInitializeExpression(argumentType, buildersNamespace, builderCollectionTypeName)));
 
+    public ClassPropertyBuilder AddCollectionBackingFieldOnImmutableClass(Type collectionType)
+    {
+        AddMetadata(MetadataNames.CustomImmutablePropertyGetterStatement, new LiteralCodeStatement($"return _{Name.ToString().ToPascalCase()};", Enumerable.Empty<IMetadata>()));
+        AddMetadata(MetadataNames.CustomImmutableConstructorInitialization, $"_{Name.ToString().ToPascalCase()} = new {typeof(ValueCollection<>).WithoutGenerics()}<{TypeName.ToString().GetGenericArguments()}>({Name.ToString().ToPascalCase()});");
+        AddMetadata(MetadataNames.CustomImmutableBackingField, new ClassFieldBuilder().WithName($"_{Name.ToString().ToPascalCase()}").WithTypeName($"{typeof(ValueCollection<>).WithoutGenerics()}<{TypeName.ToString().GetGenericArguments()}>").Build());
+
+        return this;
+    }
+
     private static string CreateDefaultCustomBuilderConstructorCollectionPropertyInitializeExpression(string? argumentType,
                                                                                                       string? buildersNamespace,
                                                                                                       string? builderCollectionTypeName)

--- a/src/ModelFramework.Objects/Extensions/TypeBaseExtensions.ImmutableBuilderClassBuilder.cs
+++ b/src/ModelFramework.Objects/Extensions/TypeBaseExtensions.ImmutableBuilderClassBuilder.cs
@@ -112,11 +112,14 @@ public static partial class TypeBaseEtensions
             yield break;
         }
 
-        foreach (var field in instance.GetFields()
+        if (settings.GenerationSettings.CopyFields)
+        {
+            foreach (var field in instance.GetFields()
             .Where(x => instance.IsMemberValidForImmutableBuilderClass(x, settings.InheritanceSettings, isForWithStatement))
             .Select(x => new ClassFieldBuilder(x).WithProtected()))
-        {
-            yield return field;
+            {
+                yield return field;
+            }
         }
 
         if (settings.GenerationSettings.UseLazyInitialization)

--- a/src/ModelFramework.Objects/MetadataNames.cs
+++ b/src/ModelFramework.Objects/MetadataNames.cs
@@ -68,6 +68,26 @@ public static class MetadataNames
     public const string CustomImmutableArgumentType = "ModelFramework.Objects.Immutable.Ctor.CustomArgumentType";
 
     /// <summary>
+    /// Metadata name for defining custom property getter statements (of type ICodeStatement) on immutable classes.
+    /// </summary>
+    public const string CustomImmutablePropertyGetterStatement = "ModelFramework.Objects.Immutable.Property.GetterStatements";
+
+    /// <summary>
+    /// Metadata name for defining custom property setter statements (of type ICodeStatement) on immutable classes.
+    /// </summary>
+    public const string CustomImmutablePropertySetterStatement = "ModelFramework.Objects.Immutable.Property.SetterStatements";
+
+    /// <summary>
+    /// Metadata name for definins custom property initialization in the c'tor (of type string) on immutable classes.
+    /// </summary>
+    public const string CustomImmutableConstructorInitialization = "ModelFramework.Objects.Immutable.ConstructorInitialization";
+
+    /// <summary>
+    /// Metadata name for definins custom backing fields (of type IClassField) on immutable classes.
+    /// </summary>
+    public const string CustomImmutableBackingField = "ModelFramework.Objects.Immutable.BackingFields";
+
+    /// <summary>
     /// Metadata name for defining a custom type for argument in immutable builder.
     /// </summary>
     public const string CustomBuilderArgumentType = "ModelFramework.Objects.Builder.ArgumentType";

--- a/src/ModelFramework.Objects/Settings/ImmutableBuilderClassGenerationSettings.cs
+++ b/src/ModelFramework.Objects/Settings/ImmutableBuilderClassGenerationSettings.cs
@@ -5,13 +5,16 @@ public record ImmutableBuilderClassGenerationSettings
     public bool UseLazyInitialization { get; }
     public bool CopyPropertyCode { get; }
     public bool AllowGenerationWithoutProperties { get; }
+    public bool CopyFields { get; }
 
     public ImmutableBuilderClassGenerationSettings(bool useLazyInitialization = false,
                                                    bool copyPropertyCode = true,
-                                                   bool allowGenerationWithoutProperties = false)
+                                                   bool allowGenerationWithoutProperties = false,
+                                                   bool copyFields = true)
     {
         UseLazyInitialization = useLazyInitialization;
         CopyPropertyCode = copyPropertyCode;
         AllowGenerationWithoutProperties = allowGenerationWithoutProperties;
+        CopyFields = copyFields;
     }
 }


### PR DESCRIPTION
Added support to immutable class builder for backing members of collection properties, so they're public read-only but privately settable.

For example, in a typical domain entity (in DDD) you want the collection to be read-only on the public property, but internally it must be able to change the state. This could be used for events, for example.