### PR TITLE
Refactor optional validation

### DIFF
--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -134,17 +134,28 @@ using System.Text;
 
 namespace Test
 {
-    public partial record TestClass
+    public partial record TestClass : TestClassBase
+    {
+        public TestClass(TestClass original) : base(original)
+        {
+        }
+
+        public TestClass(string testProperty) : base(testProperty)
+        {
+            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
+        }
+    }
+
+    public partial record TestClassBase
     {
         public string TestProperty
         {
             get;
         }
 
-        public TestClass(string testProperty)
+        public TestClassBase(string testProperty)
         {
             this.TestProperty = testProperty;
-            System.ComponentModel.DataAnnotations.Validator.ValidateObject(this, new System.ComponentModel.DataAnnotations.ValidationContext(this, null, null), true);
         }
     }
 }
@@ -194,6 +205,16 @@ namespace Test.Builders
             #pragma warning disable CS8604 // Possible null reference argument.
             return new Test.TestClass(TestProperty?.ToString());
             #pragma warning restore CS8604 // Possible null reference argument.
+        }
+
+        public System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(System.ComponentModel.DataAnnotations.ValidationContext validationContext)
+        {
+            #pragma warning disable CS8604 // Possible null reference argument.
+            var instance = new Test.TestClassBase(TestProperty?.ToString());
+            #pragma warning restore CS8604 // Possible null reference argument.
+            var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
+            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance, null, null), results, true);
+            return results;
         }
 
         public TestClassBuilder WithTestProperty(System.Text.StringBuilder testProperty)
@@ -1186,6 +1207,7 @@ namespace MyNamespace.Domain.Builders
         protected override Type RecordConcreteCollectionType => typeof(ReadOnlyCollection<>);
         protected override bool EnableNullableContext => true;
         protected override bool CreateCodeGenerationHeader => false;
+        protected override ArgumentValidationType ValidateArgumentsInConstructor => ArgumentValidationType.Optional;
 
         protected ITypeBase[] GetModels() => new[]
         {

--- a/src/ModelFramework.CodeGeneration.Tests/GlobalUsings.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/GlobalUsings.cs
@@ -18,6 +18,7 @@ global using ModelFramework.Objects.Builders;
 global using ModelFramework.Objects.CodeStatements;
 global using ModelFramework.Objects.Contracts;
 global using ModelFramework.Objects.Extensions;
+global using ModelFramework.Objects.Settings;
 global using TextTemplateTransformationFramework.Runtime;
 global using TextTemplateTransformationFramework.Runtime.CodeGeneration;
 global using Xunit;

--- a/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
+++ b/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
@@ -245,17 +245,17 @@ public abstract class CSharpClassBase : ClassBase
             .BuildTyped();
 
     protected ClassBuilder CreateBuilder(ITypeBase typeBase, string @namespace)
-        => typeBase.ToImmutableBuilderClassBuilder(CreateImmutableBuilderClassSettings())
+        => typeBase.ToImmutableBuilderClassBuilder(CreateImmutableBuilderClassSettings(ArgumentValidationType.Never))
             .WithNamespace(@namespace)
             .WithPartial();
 
     protected ClassBuilder CreateNonGenericBuilder(ITypeBase typeBase, string @namespace)
-        => typeBase.ToNonGenericImmutableBuilderClassBuilder(CreateImmutableBuilderClassSettings())
+        => typeBase.ToNonGenericImmutableBuilderClassBuilder(CreateImmutableBuilderClassSettings(ArgumentValidationType.Never))
             .WithNamespace(@namespace)
             .WithPartial();
 
     protected ClassBuilder CreateBuilderExtensions(ITypeBase typeBase, string @namespace)
-        => typeBase.ToBuilderExtensionsClassBuilder(CreateImmutableBuilderClassSettings())
+        => typeBase.ToBuilderExtensionsClassBuilder(CreateImmutableBuilderClassSettings(ArgumentValidationType.Never))
             .WithNamespace(@namespace)
             .WithPartial();
 
@@ -402,7 +402,7 @@ public abstract class CSharpClassBase : ClassBase
             ? string.Empty
             : "{0}{2}.BuildTyped()";
 
-    protected ImmutableBuilderClassSettings CreateImmutableBuilderClassSettings()
+    protected ImmutableBuilderClassSettings CreateImmutableBuilderClassSettings(ArgumentValidationType? forceValidateArgumentsInConstructor = null)
         => new
         (
             typeSettings: new(
@@ -430,16 +430,17 @@ public abstract class CSharpClassBase : ClassBase
                 inheritanceComparisonFunction: EnableBuilderInhericance
                     ? IsMemberValid
                     : (_, _) => true),
-            classSettings: CreateImmutableClassSettings()
+            classSettings: CreateImmutableClassSettings(forceValidateArgumentsInConstructor ?? ArgumentValidationType.Never)
         );
 
-    protected ImmutableClassSettings CreateImmutableClassSettings(bool forceSettings = false)
+    protected ImmutableClassSettings CreateImmutableClassSettings(ArgumentValidationType? forceValidateArgumentsInConstructor = null)
         => new
         (
             newCollectionTypeName: RecordCollectionType.WithoutGenerics(),
             allowGenerationWithoutProperties: AllowGenerationWithoutProperties,
             constructorSettings: new(
-                validateArguments: forceSettings ? ValidateArgumentsInConstructor : CombineValidateArguments(ValidateArgumentsInConstructor, !(EnableEntityInheritance && BaseClass == null)),
+                validateArguments: forceValidateArgumentsInConstructor ?? CombineValidateArguments(ValidateArgumentsInConstructor, !(EnableEntityInheritance && BaseClass == null)),
+                originalValidateArguments: ValidateArgumentsInConstructor,
                 addNullChecks: AddNullChecks),
             addPrivateSetters: AddPrivateSetters,
             inheritanceSettings: new(
@@ -538,7 +539,7 @@ public abstract class CSharpClassBase : ClassBase
             .WithNamespace(entitiesNamespace)
             .With(x => FixImmutableBuilderProperties(x))
             .Build()
-            .ToImmutableClassBuilder(CreateImmutableClassSettings())
+            .ToImmutableClassBuilder(CreateImmutableClassSettings(ArgumentValidationType.Never))
             .BuildTyped();
 
     private ITypeBase CreateImmutableClassFromInterface(IInterface iinterface, string entitiesNamespace)
@@ -580,7 +581,7 @@ public abstract class CSharpClassBase : ClassBase
             .WithNamespace(entitiesNamespace)
             .With(x => FixImmutableClassProperties(x))
             .Build()
-            .ToImmutableClassValidateOverrideBuilder(CreateImmutableClassSettings(true))
+            .ToImmutableClassValidateOverrideBuilder(CreateImmutableClassSettings(ValidateArgumentsInConstructor))
             .WithRecord()
             .WithPartial()
             .Build();

--- a/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
+++ b/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
@@ -179,7 +179,21 @@ public abstract class CSharpClassBase : ClassBase
             : x.ToClassBuilder().With(x => FixImmutableClassProperties(x)).Build()).ToArray(), entitiesNamespace);
 
     protected ITypeBase[] GetImmutableClasses(ITypeBase[] models, string entitiesNamespace)
-        => models.Select
+    {
+        if (ValidateArgumentsInConstructor == ArgumentValidationType.Optional)
+        {
+            return models.SelectMany
+            (
+                x => x switch
+                {
+                    IClass cls => new[] { CreateImmutableClassFromClass(cls, entitiesNamespace), CreateImmutableOverrideClassFromClass(cls, entitiesNamespace)  },
+                    IInterface iinterface => new[] { CreateImmutableClassFromInterface(iinterface, entitiesNamespace), CreateImmutableOverrideClassFromInterface(iinterface, entitiesNamespace) },
+                    _ => throw new NotSupportedException("Type of class should be IClass or IInterface")
+                }
+            ).ToArray();
+        }
+
+        return models.Select
         (
             x => x switch
             {
@@ -188,6 +202,7 @@ public abstract class CSharpClassBase : ClassBase
                 _ => throw new NotSupportedException("Type of class should be IClass or IInterface")
             }
         ).ToArray();
+    }
 
     protected IClass[] GetClassesFromSameNamespace(Type type)
     {
@@ -418,13 +433,13 @@ public abstract class CSharpClassBase : ClassBase
             classSettings: CreateImmutableClassSettings()
         );
 
-    protected ImmutableClassSettings CreateImmutableClassSettings()
+    protected ImmutableClassSettings CreateImmutableClassSettings(bool forceSettings = false)
         => new
         (
             newCollectionTypeName: RecordCollectionType.WithoutGenerics(),
             allowGenerationWithoutProperties: AllowGenerationWithoutProperties,
             constructorSettings: new(
-                validateArguments: CombineValidateArguments(ValidateArgumentsInConstructor, !(EnableEntityInheritance && BaseClass == null)),
+                validateArguments: forceSettings ? ValidateArgumentsInConstructor : CombineValidateArguments(ValidateArgumentsInConstructor, !(EnableEntityInheritance && BaseClass == null)),
                 addNullChecks: AddNullChecks),
             addPrivateSetters: AddPrivateSetters,
             inheritanceSettings: new(
@@ -538,12 +553,34 @@ public abstract class CSharpClassBase : ClassBase
             .AddInterfaces((new[] { iinterface.GetFullName() }).Where(_ => InheritFromInterfaces))
             .Build();
 
+    private ITypeBase CreateImmutableOverrideClassFromInterface(IInterface iinterface, string entitiesNamespace)
+        => new InterfaceBuilder(iinterface)
+            .WithName(iinterface.GetEntityClassName())
+            .WithNamespace(entitiesNamespace)
+            .With(x => FixImmutableClassProperties(x))
+            .Build()
+            .ToImmutableClassValidateOverrideBuilder(CreateImmutableClassSettings())
+            .WithRecord()
+            .WithPartial()
+            .AddInterfaces((new[] { iinterface.GetFullName() }).Where(_ => InheritFromInterfaces))
+            .Build();
+
     private ITypeBase CreateImmutableClassFromClass(IClass cls, string entitiesNamespace)
         => new ClassBuilder(cls)
             .WithNamespace(entitiesNamespace)
             .With(x => FixImmutableClassProperties(x))
             .Build()
             .ToImmutableClassBuilder(CreateImmutableClassSettings())
+            .WithRecord()
+            .WithPartial()
+            .Build();
+
+    private ITypeBase CreateImmutableOverrideClassFromClass(IClass cls, string entitiesNamespace)
+        => new ClassBuilder(cls)
+            .WithNamespace(entitiesNamespace)
+            .With(x => FixImmutableClassProperties(x))
+            .Build()
+            .ToImmutableClassValidateOverrideBuilder(CreateImmutableClassSettings(true))
             .WithRecord()
             .WithPartial()
             .Build();

--- a/src/ModelFramework.Generators.Objects.Tests/POC/SharedValidation.cs
+++ b/src/ModelFramework.Generators.Objects.Tests/POC/SharedValidation.cs
@@ -1,20 +1,28 @@
 ﻿namespace ModelFramework.Generators.Objects.Tests.POC;
 
-public record MySharedValidationDomainEntity1
+public record MySharedValidationDomainEntity1Base
 {
     [Required]
     public string Name { get; }
     [Range(1, 100)]
     public int Age { get; }
 
-    public MySharedValidationDomainEntity1(string name, int age, bool validate = true)
+    public MySharedValidationDomainEntity1Base(string name, int age)
     {
         Name = name;
         Age = age;
-        if (validate)
-        {
-            Validator.ValidateObject(this, new ValidationContext(this, null, null), true);
-        }
+    }
+}
+
+public record MySharedValidationDomainEntity1 : MySharedValidationDomainEntity1Base
+{
+    public MySharedValidationDomainEntity1(MySharedValidationDomainEntity1 original) : base(original)
+    {
+    }
+
+    public MySharedValidationDomainEntity1(string name, int age) : base(name, age)
+    {
+        Validator.ValidateObject(this, new ValidationContext(this, null, null), true);
     }
 }
 
@@ -23,11 +31,11 @@ public class MySharedValidationDomainEntityBuilder : IValidatableObject
     public StringBuilder Name { get; set; }
     public int Age { get; set; }
 
-    public MySharedValidationDomainEntity1 Build() => new(Name.ToString(), Age, true);
+    public MySharedValidationDomainEntity1 Build() => new(Name.ToString(), Age);
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        var instance = new MySharedValidationDomainEntity1(Name.ToString(), Age, false);
+        var instance = new MySharedValidationDomainEntity1Base(Name.ToString(), Age);
         var results = new List<ValidationResult>();
         Validator.TryValidateObject(instance, new ValidationContext(instance, null, null), results, true);
         return results;

--- a/src/ModelFramework.Objects/Extensions/TypeBaseExtensions.ImmutableBuilderClassBuilder.cs
+++ b/src/ModelFramework.Objects/Extensions/TypeBaseExtensions.ImmutableBuilderClassBuilder.cs
@@ -426,7 +426,7 @@ public static partial class TypeBaseEtensions
             }
         }
 
-        if (settings.ClassSettings.ConstructorSettings.ValidateArguments == ArgumentValidationType.Optional)
+        if (settings.ClassSettings.ConstructorSettings.OriginalValidateArguments == ArgumentValidationType.Optional && !settings.IsBuilderForAbstractEntity)
         {
             // Allow validation of the builder by calling the validate method on the entity
             yield return CreateValidateMethod(instance, settings);

--- a/src/ModelFramework.Objects/Settings/ImmutableClassConstructorSettings.cs
+++ b/src/ModelFramework.Objects/Settings/ImmutableClassConstructorSettings.cs
@@ -10,14 +10,17 @@ public enum ArgumentValidationType
 public class ImmutableClassConstructorSettings
 {
     public ArgumentValidationType ValidateArguments { get; }
+    public ArgumentValidationType OriginalValidateArguments { get; }
     public bool AddNullChecks { get; }
     public string CollectionTypeName { get; }
 
     public ImmutableClassConstructorSettings(ArgumentValidationType validateArguments = ArgumentValidationType.Never,
+                                             ArgumentValidationType? originalValidateArguments = null,
                                              bool addNullChecks = false,
                                              string collectionTypeName = "")
     {
         ValidateArguments = validateArguments;
+        OriginalValidateArguments = originalValidateArguments ?? validateArguments;
         AddNullChecks = addNullChecks;
         CollectionTypeName = collectionTypeName;
     }


### PR DESCRIPTION
Refactored optional validation, so that domain objects can never be instanciated using invalid state.

The domain entity now derives from a base class that holds the validation. The constructor of the domain entity always validates the instance. From the builder, you can use the base class to skip the validation. In the rest of the application, you should probably never use the base class.