### PR TITLE
Small refactoring

### DIFF
--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/ModelFrameworkModelClassBase.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationProviders/ModelFrameworkModelClassBase.cs
@@ -27,13 +27,12 @@ public abstract class ModelFrameworkModelClassBase : ModelFrameworkCSharpClassBa
             var defaultCustomBuilderMethodParameterExpression = property.IsNullable || AddNullChecks
                 ? "{0}?.ToEntity()"
                 : "{0}{2}.ToEntity()";
-            property.ConvertSinglePropertyToBuilderOnBuilder
-            (
-                typeName.Replace("Contracts.I", "Models.", StringComparison.InvariantCulture) + "Model",
-                customBuilderMethodParameterExpression: isClass
-                    ? "{0}{2}.ToTypedEntity()"
-                    : defaultCustomBuilderMethodParameterExpression
-            );
+            var argumentType = typeName.Replace("Contracts.I", "Models.", StringComparison.InvariantCulture) + "Model";
+            property.WithCustomBuilderConstructorInitializeExpressionSingleProperty(argumentType);
+            property.WithCustomBuilderArgumentTypeSingleProperty(argumentType);
+            property.WithCustomBuilderMethodParameterExpression(isClass
+                ? "{0}{2}.ToTypedEntity()"
+                : defaultCustomBuilderMethodParameterExpression);
         }
         else if (typeName.Contains("Collection<ModelFramework.", StringComparison.InvariantCulture))
         {

--- a/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
+++ b/src/ModelFramework.CodeGeneration/CodeGenerationProviders/CSharpClassBase.cs
@@ -347,12 +347,11 @@ public abstract class CSharpClassBase : ClassBase
             return;
         }
 
+        property.ConvertCollectionOnBuilderToEnumerable(false, RecordConcreteCollectionType.WithoutGenerics());
         if (TypeNameNeedsSpecialTreatmentForBuilderInCollection(typeName))
         {
             property.ConvertCollectionPropertyToBuilderOnBuilder
             (
-                false,
-                RecordConcreteCollectionType.WithoutGenerics(),
                 GetCustomCollectionArgumentType(typeName),
                 GetCustomBuilderConstructorInitializeExpressionForCollectionProperty(typeName),
                 builderCollectionTypeName: GetBuilderClassCollectionTypeName(),
@@ -364,8 +363,6 @@ public abstract class CSharpClassBase : ClassBase
         {
             property.ConvertCollectionPropertyToBuilderOnBuilder
             (
-                false,
-                RecordConcreteCollectionType.WithoutGenerics(),
                 GetCustomCollectionArgumentType(typeName),
                 customBuilderMethodParameterExpression: GetCustomBuilderMethodParameterExpressionForCollectionProperty(typeName),
                 builderCollectionTypeName: GetBuilderClassCollectionTypeName(),
@@ -383,16 +380,13 @@ public abstract class CSharpClassBase : ClassBase
             return;
         }
 
-        property.ConvertSinglePropertyToBuilderOnBuilder
-        (
-            !string.IsNullOrEmpty(typeName.GetGenericArguments())
+        var argumentType = !string.IsNullOrEmpty(typeName.GetGenericArguments())
                 ? $"{GetBuilderNamespace(typeName.WithoutProcessedGenerics())}.{typeName.WithoutProcessedGenerics().GetClassName()}{BuilderName}<{typeName.GetGenericArguments()}>"
-                : $"{GetBuilderNamespace(typeName)}.{typeName.GetClassName()}{BuilderName}",
-            GetCustomBuilderConstructorInitializeExpressionForSingleProperty(property, typeName),
-            GetCustomBuilderMethodParameterExpression(typeName),
-            builderName: BuilderName,
-            buildMethodName: BuilderBuildMethodName
-        );
+                : $"{GetBuilderNamespace(typeName)}.{typeName.GetClassName()}{BuilderName}";
+
+        property.WithCustomBuilderConstructorInitializeExpressionSingleProperty(argumentType, GetCustomBuilderConstructorInitializeExpressionForSingleProperty(property, typeName));
+        property.WithCustomBuilderArgumentTypeSingleProperty(argumentType, BuilderName);
+        property.WithCustomBuilderMethodParameterExpression(GetCustomBuilderMethodParameterExpression(typeName), BuilderBuildMethodName);
 
         if (!property.IsNullable)
         {

--- a/src/ModelFramework.Database/Builders/ForeignKeyConstraintBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/ForeignKeyConstraintBuilder.generated.cs
@@ -234,8 +234,8 @@ namespace ModelFramework.Database.Builders
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
             _foreignTableNameDelegate = new (() => new System.Text.StringBuilder());
-            _cascadeUpdateDelegate = new (() => default(ModelFramework.Database.Contracts.CascadeAction));
-            _cascadeDeleteDelegate = new (() => default(ModelFramework.Database.Contracts.CascadeAction));
+            _cascadeUpdateDelegate = new (() => default(ModelFramework.Database.Contracts.CascadeAction)!);
+            _cascadeDeleteDelegate = new (() => default(ModelFramework.Database.Contracts.CascadeAction)!);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Builders/IndexBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/IndexBuilder.generated.cs
@@ -191,7 +191,7 @@ namespace ModelFramework.Database.Builders
             Fields = new System.Collections.Generic.List<ModelFramework.Database.Builders.IndexFieldBuilder>();
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _uniqueDelegate = new (() => default(bool));
+            _uniqueDelegate = new (() => default(bool)!);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             _fileGroupNameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Database/Builders/IndexFieldBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/IndexFieldBuilder.generated.cs
@@ -125,7 +125,7 @@ namespace ModelFramework.Database.Builders
         {
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _isDescendingDelegate = new (() => default(bool));
+            _isDescendingDelegate = new (() => default(bool)!);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Builders/PrimaryKeyConstraintFieldBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/PrimaryKeyConstraintFieldBuilder.generated.cs
@@ -125,7 +125,7 @@ namespace ModelFramework.Database.Builders
         {
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _isDescendingDelegate = new (() => default(bool));
+            _isDescendingDelegate = new (() => default(bool)!);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Builders/TableFieldBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/TableFieldBuilder.generated.cs
@@ -360,13 +360,13 @@ namespace ModelFramework.Database.Builders
             CheckConstraints = new System.Collections.Generic.List<ModelFramework.Database.Builders.CheckConstraintBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
             _typeDelegate = new (() => new System.Text.StringBuilder());
-            _isIdentityDelegate = new (() => default(bool));
-            _isRequiredDelegate = new (() => default(bool));
+            _isIdentityDelegate = new (() => default(bool)!);
+            _isRequiredDelegate = new (() => default(bool)!);
             _numericPrecisionDelegate = new (() => default(System.Nullable<byte>));
             _numericScaleDelegate = new (() => default(System.Nullable<byte>));
             _stringLengthDelegate = new (() => default(System.Nullable<int>));
             _stringCollationDelegate = new (() => new System.Text.StringBuilder());
-            _isStringMaxLengthDelegate = new (() => default(bool));
+            _isStringMaxLengthDelegate = new (() => default(bool)!);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Builders/ViewBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/ViewBuilder.generated.cs
@@ -312,8 +312,8 @@ namespace ModelFramework.Database.Builders
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
             _topDelegate = new (() => default(System.Nullable<int>));
-            _topPercentDelegate = new (() => default(bool));
-            _distinctDelegate = new (() => default(bool));
+            _topPercentDelegate = new (() => default(bool)!);
+            _distinctDelegate = new (() => default(bool)!);
             _definitionDelegate = new (() => new System.Text.StringBuilder());
             _nameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Database/Builders/ViewOrderByFieldBuilder.generated.cs
+++ b/src/ModelFramework.Database/Builders/ViewOrderByFieldBuilder.generated.cs
@@ -317,7 +317,7 @@ namespace ModelFramework.Database.Builders
         {
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _isDescendingDelegate = new (() => default(bool));
+            _isDescendingDelegate = new (() => default(bool)!);
             _sourceSchemaNameDelegate = new (() => new System.Text.StringBuilder());
             _sourceObjectNameDelegate = new (() => new System.Text.StringBuilder());
             _expressionDelegate = new (() => new System.Text.StringBuilder());

--- a/src/ModelFramework.Database/Models/ForeignKeyConstraintModel.generated.cs
+++ b/src/ModelFramework.Database/Models/ForeignKeyConstraintModel.generated.cs
@@ -75,8 +75,8 @@ namespace ModelFramework.Database.Models
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
             ForeignTableName = string.Empty;
-            CascadeUpdate = default(ModelFramework.Database.Contracts.CascadeAction);
-            CascadeDelete = default(ModelFramework.Database.Contracts.CascadeAction);
+            CascadeUpdate = default(ModelFramework.Database.Contracts.CascadeAction)!;
+            CascadeDelete = default(ModelFramework.Database.Contracts.CascadeAction)!;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Models/IndexFieldModel.generated.cs
+++ b/src/ModelFramework.Database/Models/IndexFieldModel.generated.cs
@@ -48,7 +48,7 @@ namespace ModelFramework.Database.Models
         {
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            IsDescending = default(System.Boolean);
+            IsDescending = default(System.Boolean)!;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Models/IndexModel.generated.cs
+++ b/src/ModelFramework.Database/Models/IndexModel.generated.cs
@@ -61,7 +61,7 @@ namespace ModelFramework.Database.Models
             Fields = new System.Collections.Generic.List<ModelFramework.Database.Models.IndexFieldModel>();
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            Unique = default(System.Boolean);
+            Unique = default(System.Boolean)!;
             Name = string.Empty;
             FileGroupName = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Database/Models/PrimaryKeyConstraintFieldModel.generated.cs
+++ b/src/ModelFramework.Database/Models/PrimaryKeyConstraintFieldModel.generated.cs
@@ -48,7 +48,7 @@ namespace ModelFramework.Database.Models
         {
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            IsDescending = default(System.Boolean);
+            IsDescending = default(System.Boolean)!;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Models/TableFieldModel.generated.cs
+++ b/src/ModelFramework.Database/Models/TableFieldModel.generated.cs
@@ -98,10 +98,10 @@ namespace ModelFramework.Database.Models
             CheckConstraints = new System.Collections.Generic.List<ModelFramework.Database.Models.CheckConstraintModel>();
             #pragma warning disable CS8603 // Possible null reference return.
             Type = string.Empty;
-            IsIdentity = default(System.Boolean);
-            IsRequired = default(System.Boolean);
+            IsIdentity = default(System.Boolean)!;
+            IsRequired = default(System.Boolean)!;
             StringCollation = string.Empty;
-            IsStringMaxLength = default(System.Boolean);
+            IsStringMaxLength = default(System.Boolean)!;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Database/Models/ViewModel.generated.cs
+++ b/src/ModelFramework.Database/Models/ViewModel.generated.cs
@@ -101,8 +101,8 @@ namespace ModelFramework.Database.Models
             Conditions = new System.Collections.Generic.List<ModelFramework.Database.Models.ViewConditionModel>();
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            TopPercent = default(System.Boolean);
-            Distinct = default(System.Boolean);
+            TopPercent = default(System.Boolean)!;
+            Distinct = default(System.Boolean)!;
             Definition = string.Empty;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Database/Models/ViewOrderByFieldModel.generated.cs
+++ b/src/ModelFramework.Database/Models/ViewOrderByFieldModel.generated.cs
@@ -72,7 +72,7 @@ namespace ModelFramework.Database.Models
         {
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            IsDescending = default(System.Boolean);
+            IsDescending = default(System.Boolean)!;
             SourceSchemaName = string.Empty;
             SourceObjectName = string.Empty;
             Expression = string.Empty;

--- a/src/ModelFramework.Objects/Builders/ClassBuilder.generated.cs
+++ b/src/ModelFramework.Objects/Builders/ClassBuilder.generated.cs
@@ -245,11 +245,11 @@ namespace ModelFramework.Objects.Builders
             Constructors = new System.Collections.Generic.List<ModelFramework.Objects.Builders.ClassConstructorBuilder>();
             Enums = new System.Collections.Generic.List<ModelFramework.Objects.Builders.EnumBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _staticDelegate = new (() => default(bool));
-            _sealedDelegate = new (() => default(bool));
-            _abstractDelegate = new (() => default(bool));
+            _staticDelegate = new (() => default(bool)!);
+            _sealedDelegate = new (() => default(bool)!);
+            _abstractDelegate = new (() => default(bool)!);
             _baseClassDelegate = new (() => new System.Text.StringBuilder());
-            _recordDelegate = new (() => default(bool));
+            _recordDelegate = new (() => default(bool)!);
             #pragma warning restore CS8603 // Possible null reference return.
         }
 

--- a/src/ModelFramework.Objects/Builders/ClassConstructorBuilder.generated.cs
+++ b/src/ModelFramework.Objects/Builders/ClassConstructorBuilder.generated.cs
@@ -336,11 +336,11 @@ namespace ModelFramework.Objects.Builders
             Parameters = new System.Collections.Generic.List<ModelFramework.Objects.Builders.ParameterBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
             _chainCallDelegate = new (() => new System.Text.StringBuilder());
-            _staticDelegate = new (() => default(bool));
-            _virtualDelegate = new (() => default(bool));
-            _abstractDelegate = new (() => default(bool));
-            _protectedDelegate = new (() => default(bool));
-            _overrideDelegate = new (() => default(bool));
+            _staticDelegate = new (() => default(bool)!);
+            _virtualDelegate = new (() => default(bool)!);
+            _abstractDelegate = new (() => default(bool)!);
+            _protectedDelegate = new (() => default(bool)!);
+            _overrideDelegate = new (() => default(bool)!);
             _visibilityDelegate = new (() => ModelFramework.Objects.Contracts.Visibility.Public);
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Objects/Builders/ClassFieldBuilder.generated.cs
+++ b/src/ModelFramework.Objects/Builders/ClassFieldBuilder.generated.cs
@@ -509,19 +509,19 @@ namespace ModelFramework.Objects.Builders
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             Attributes = new System.Collections.Generic.List<ModelFramework.Objects.Builders.AttributeBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _readOnlyDelegate = new (() => default(bool));
-            _constantDelegate = new (() => default(bool));
-            _eventDelegate = new (() => default(bool));
-            _staticDelegate = new (() => default(bool));
-            _virtualDelegate = new (() => default(bool));
-            _abstractDelegate = new (() => default(bool));
-            _protectedDelegate = new (() => default(bool));
-            _overrideDelegate = new (() => default(bool));
+            _readOnlyDelegate = new (() => default(bool)!);
+            _constantDelegate = new (() => default(bool)!);
+            _eventDelegate = new (() => default(bool)!);
+            _staticDelegate = new (() => default(bool)!);
+            _virtualDelegate = new (() => default(bool)!);
+            _abstractDelegate = new (() => default(bool)!);
+            _protectedDelegate = new (() => default(bool)!);
+            _overrideDelegate = new (() => default(bool)!);
             _visibilityDelegate = new (() => ModelFramework.Objects.Contracts.Visibility.Private);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             _typeNameDelegate = new (() => new System.Text.StringBuilder());
-            _isNullableDelegate = new (() => default(bool));
-            _isValueTypeDelegate = new (() => default(bool));
+            _isNullableDelegate = new (() => default(bool)!);
+            _isValueTypeDelegate = new (() => default(bool)!);
             _defaultValueDelegate = new (() => default(object?));
             _parentTypeFullNameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Builders/ClassMethodBuilder.generated.cs
+++ b/src/ModelFramework.Objects/Builders/ClassMethodBuilder.generated.cs
@@ -665,20 +665,20 @@ namespace ModelFramework.Objects.Builders
             CodeStatements = new System.Collections.Generic.List<ModelFramework.Objects.Contracts.ICodeStatementBuilder>();
             Parameters = new System.Collections.Generic.List<ModelFramework.Objects.Builders.ParameterBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _partialDelegate = new (() => default(bool));
-            _extensionMethodDelegate = new (() => default(bool));
-            _operatorDelegate = new (() => default(bool));
-            _asyncDelegate = new (() => default(bool));
-            _staticDelegate = new (() => default(bool));
-            _virtualDelegate = new (() => default(bool));
-            _abstractDelegate = new (() => default(bool));
-            _protectedDelegate = new (() => default(bool));
-            _overrideDelegate = new (() => default(bool));
+            _partialDelegate = new (() => default(bool)!);
+            _extensionMethodDelegate = new (() => default(bool)!);
+            _operatorDelegate = new (() => default(bool)!);
+            _asyncDelegate = new (() => default(bool)!);
+            _staticDelegate = new (() => default(bool)!);
+            _virtualDelegate = new (() => default(bool)!);
+            _abstractDelegate = new (() => default(bool)!);
+            _protectedDelegate = new (() => default(bool)!);
+            _overrideDelegate = new (() => default(bool)!);
             _visibilityDelegate = new (() => ModelFramework.Objects.Contracts.Visibility.Public);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             _typeNameDelegate = new (() => new System.Text.StringBuilder());
-            _isNullableDelegate = new (() => default(bool));
-            _isValueTypeDelegate = new (() => default(bool));
+            _isNullableDelegate = new (() => default(bool)!);
+            _isValueTypeDelegate = new (() => default(bool)!);
             _explicitInterfaceNameDelegate = new (() => new System.Text.StringBuilder());
             _parentTypeFullNameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Builders/ClassPropertyBuilder.generated.cs
+++ b/src/ModelFramework.Objects/Builders/ClassPropertyBuilder.generated.cs
@@ -677,20 +677,20 @@ namespace ModelFramework.Objects.Builders
             #pragma warning disable CS8603 // Possible null reference return.
             _hasGetterDelegate = new (() => true);
             _hasSetterDelegate = new (() => true);
-            _hasInitializerDelegate = new (() => default(bool));
+            _hasInitializerDelegate = new (() => default(bool)!);
             _getterVisibilityDelegate = new (() => default(System.Nullable<ModelFramework.Objects.Contracts.Visibility>));
             _setterVisibilityDelegate = new (() => default(System.Nullable<ModelFramework.Objects.Contracts.Visibility>));
             _initializerVisibilityDelegate = new (() => default(System.Nullable<ModelFramework.Objects.Contracts.Visibility>));
-            _staticDelegate = new (() => default(bool));
-            _virtualDelegate = new (() => default(bool));
-            _abstractDelegate = new (() => default(bool));
-            _protectedDelegate = new (() => default(bool));
-            _overrideDelegate = new (() => default(bool));
+            _staticDelegate = new (() => default(bool)!);
+            _virtualDelegate = new (() => default(bool)!);
+            _abstractDelegate = new (() => default(bool)!);
+            _protectedDelegate = new (() => default(bool)!);
+            _overrideDelegate = new (() => default(bool)!);
             _visibilityDelegate = new (() => ModelFramework.Objects.Contracts.Visibility.Public);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             _typeNameDelegate = new (() => new System.Text.StringBuilder());
-            _isNullableDelegate = new (() => default(bool));
-            _isValueTypeDelegate = new (() => default(bool));
+            _isNullableDelegate = new (() => default(bool)!);
+            _isValueTypeDelegate = new (() => default(bool)!);
             _explicitInterfaceNameDelegate = new (() => new System.Text.StringBuilder());
             _parentTypeFullNameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Builders/ParameterBuilder.generated.cs
+++ b/src/ModelFramework.Objects/Builders/ParameterBuilder.generated.cs
@@ -317,12 +317,12 @@ namespace ModelFramework.Objects.Builders
             Attributes = new System.Collections.Generic.List<ModelFramework.Objects.Builders.AttributeBuilder>();
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Builders.MetadataBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
-            _isParamArrayDelegate = new (() => default(bool));
-            _isOutDelegate = new (() => default(bool));
-            _isRefDelegate = new (() => default(bool));
+            _isParamArrayDelegate = new (() => default(bool)!);
+            _isOutDelegate = new (() => default(bool)!);
+            _isRefDelegate = new (() => default(bool)!);
             _typeNameDelegate = new (() => new System.Text.StringBuilder());
-            _isNullableDelegate = new (() => default(bool));
-            _isValueTypeDelegate = new (() => default(bool));
+            _isNullableDelegate = new (() => default(bool)!);
+            _isValueTypeDelegate = new (() => default(bool)!);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             _defaultValueDelegate = new (() => default(object?));
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Builders/TypeBaseBuilder.nongeneric.template.generated.cs
+++ b/src/ModelFramework.Objects/Builders/TypeBaseBuilder.nongeneric.template.generated.cs
@@ -120,7 +120,7 @@ namespace ModelFramework.Objects.Builders
             Attributes = new System.Collections.Generic.List<ModelFramework.Objects.Builders.AttributeBuilder>();
             #pragma warning disable CS8603 // Possible null reference return.
             _namespaceDelegate = new (() => new System.Text.StringBuilder());
-            _partialDelegate = new (() => default(bool));
+            _partialDelegate = new (() => default(bool)!);
             _visibilityDelegate = new (() => ModelFramework.Objects.Contracts.Visibility.Public);
             _nameDelegate = new (() => new System.Text.StringBuilder());
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Models/ClassConstructorModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/ClassConstructorModel.generated.cs
@@ -100,12 +100,12 @@ namespace ModelFramework.Objects.Models
             Parameters = new System.Collections.Generic.List<ModelFramework.Objects.Models.ParameterModel>();
             #pragma warning disable CS8603 // Possible null reference return.
             ChainCall = string.Empty;
-            Static = default(System.Boolean);
-            Virtual = default(System.Boolean);
-            Abstract = default(System.Boolean);
-            Protected = default(System.Boolean);
-            Override = default(System.Boolean);
-            Visibility = default(ModelFramework.Objects.Contracts.Visibility);
+            Static = default(System.Boolean)!;
+            Virtual = default(System.Boolean)!;
+            Abstract = default(System.Boolean)!;
+            Protected = default(System.Boolean)!;
+            Override = default(System.Boolean)!;
+            Visibility = default(ModelFramework.Objects.Contracts.Visibility)!;
             #pragma warning restore CS8603 // Possible null reference return.
         }
 

--- a/src/ModelFramework.Objects/Models/ClassFieldModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/ClassFieldModel.generated.cs
@@ -133,19 +133,19 @@ namespace ModelFramework.Objects.Models
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             Attributes = new System.Collections.Generic.List<ModelFramework.Objects.Models.AttributeModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            ReadOnly = default(System.Boolean);
-            Constant = default(System.Boolean);
-            Event = default(System.Boolean);
-            Static = default(System.Boolean);
-            Virtual = default(System.Boolean);
-            Abstract = default(System.Boolean);
-            Protected = default(System.Boolean);
-            Override = default(System.Boolean);
-            Visibility = default(ModelFramework.Objects.Contracts.Visibility);
+            ReadOnly = default(System.Boolean)!;
+            Constant = default(System.Boolean)!;
+            Event = default(System.Boolean)!;
+            Static = default(System.Boolean)!;
+            Virtual = default(System.Boolean)!;
+            Abstract = default(System.Boolean)!;
+            Protected = default(System.Boolean)!;
+            Override = default(System.Boolean)!;
+            Visibility = default(ModelFramework.Objects.Contracts.Visibility)!;
             Name = string.Empty;
             TypeName = string.Empty;
-            IsNullable = default(System.Boolean);
-            IsValueType = default(System.Boolean);
+            IsNullable = default(System.Boolean)!;
+            IsValueType = default(System.Boolean)!;
             ParentTypeFullName = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Objects/Models/ClassMethodModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/ClassMethodModel.generated.cs
@@ -167,20 +167,20 @@ namespace ModelFramework.Objects.Models
             CodeStatements = new System.Collections.Generic.List<ModelFramework.Objects.Contracts.ICodeStatementModel>();
             Parameters = new System.Collections.Generic.List<ModelFramework.Objects.Models.ParameterModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            Partial = default(System.Boolean);
-            ExtensionMethod = default(System.Boolean);
-            Operator = default(System.Boolean);
-            Async = default(System.Boolean);
-            Static = default(System.Boolean);
-            Virtual = default(System.Boolean);
-            Abstract = default(System.Boolean);
-            Protected = default(System.Boolean);
-            Override = default(System.Boolean);
-            Visibility = default(ModelFramework.Objects.Contracts.Visibility);
+            Partial = default(System.Boolean)!;
+            ExtensionMethod = default(System.Boolean)!;
+            Operator = default(System.Boolean)!;
+            Async = default(System.Boolean)!;
+            Static = default(System.Boolean)!;
+            Virtual = default(System.Boolean)!;
+            Abstract = default(System.Boolean)!;
+            Protected = default(System.Boolean)!;
+            Override = default(System.Boolean)!;
+            Visibility = default(ModelFramework.Objects.Contracts.Visibility)!;
             Name = string.Empty;
             TypeName = string.Empty;
-            IsNullable = default(System.Boolean);
-            IsValueType = default(System.Boolean);
+            IsNullable = default(System.Boolean)!;
+            IsValueType = default(System.Boolean)!;
             ExplicitInterfaceName = string.Empty;
             ParentTypeFullName = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Models/ClassModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/ClassModel.generated.cs
@@ -87,11 +87,11 @@ namespace ModelFramework.Objects.Models
             Constructors = new System.Collections.Generic.List<ModelFramework.Objects.Models.ClassConstructorModel>();
             Enums = new System.Collections.Generic.List<ModelFramework.Objects.Models.EnumModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            Static = default(System.Boolean);
-            Sealed = default(System.Boolean);
-            Abstract = default(System.Boolean);
+            Static = default(System.Boolean)!;
+            Sealed = default(System.Boolean)!;
+            Abstract = default(System.Boolean)!;
             BaseClass = string.Empty;
-            Record = default(System.Boolean);
+            Record = default(System.Boolean)!;
             #pragma warning restore CS8603 // Possible null reference return.
         }
 

--- a/src/ModelFramework.Objects/Models/ClassPropertyModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/ClassPropertyModel.generated.cs
@@ -174,17 +174,17 @@ namespace ModelFramework.Objects.Models
             #pragma warning disable CS8603 // Possible null reference return.
             HasGetter = true;
             HasSetter = true;
-            HasInitializer = default(System.Boolean);
-            Static = default(System.Boolean);
-            Virtual = default(System.Boolean);
-            Abstract = default(System.Boolean);
-            Protected = default(System.Boolean);
-            Override = default(System.Boolean);
-            Visibility = default(ModelFramework.Objects.Contracts.Visibility);
+            HasInitializer = default(System.Boolean)!;
+            Static = default(System.Boolean)!;
+            Virtual = default(System.Boolean)!;
+            Abstract = default(System.Boolean)!;
+            Protected = default(System.Boolean)!;
+            Override = default(System.Boolean)!;
+            Visibility = default(ModelFramework.Objects.Contracts.Visibility)!;
             Name = string.Empty;
             TypeName = string.Empty;
-            IsNullable = default(System.Boolean);
-            IsValueType = default(System.Boolean);
+            IsNullable = default(System.Boolean)!;
+            IsValueType = default(System.Boolean)!;
             ExplicitInterfaceName = string.Empty;
             ParentTypeFullName = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.

--- a/src/ModelFramework.Objects/Models/EnumModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/EnumModel.generated.cs
@@ -63,7 +63,7 @@ namespace ModelFramework.Objects.Models
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
             Name = string.Empty;
-            Visibility = default(ModelFramework.Objects.Contracts.Visibility);
+            Visibility = default(ModelFramework.Objects.Contracts.Visibility)!;
             #pragma warning restore CS8603 // Possible null reference return.
         }
 

--- a/src/ModelFramework.Objects/Models/ParameterModel.generated.cs
+++ b/src/ModelFramework.Objects/Models/ParameterModel.generated.cs
@@ -91,12 +91,12 @@ namespace ModelFramework.Objects.Models
             Attributes = new System.Collections.Generic.List<ModelFramework.Objects.Models.AttributeModel>();
             Metadata = new System.Collections.Generic.List<ModelFramework.Common.Models.MetadataModel>();
             #pragma warning disable CS8603 // Possible null reference return.
-            IsParamArray = default(System.Boolean);
-            IsOut = default(System.Boolean);
-            IsRef = default(System.Boolean);
+            IsParamArray = default(System.Boolean)!;
+            IsOut = default(System.Boolean)!;
+            IsRef = default(System.Boolean)!;
             TypeName = string.Empty;
-            IsNullable = default(System.Boolean);
-            IsValueType = default(System.Boolean);
+            IsNullable = default(System.Boolean)!;
+            IsValueType = default(System.Boolean)!;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }

--- a/src/ModelFramework.Objects/Models/TypeBaseModel.nongeneric.template.generated.cs
+++ b/src/ModelFramework.Objects/Models/TypeBaseModel.nongeneric.template.generated.cs
@@ -96,8 +96,8 @@ namespace ModelFramework.Objects.Models
             Attributes = new System.Collections.Generic.List<ModelFramework.Objects.Models.AttributeModel>();
             #pragma warning disable CS8603 // Possible null reference return.
             Namespace = string.Empty;
-            Partial = default(System.Boolean);
-            Visibility = default(ModelFramework.Objects.Contracts.Visibility);
+            Partial = default(System.Boolean)!;
+            Visibility = default(ModelFramework.Objects.Contracts.Visibility)!;
             Name = string.Empty;
             #pragma warning restore CS8603 // Possible null reference return.
         }


### PR DESCRIPTION
Refactored code to fix code smells (too many arguments on methods), and regenerated everything to reflect recent changes in generator.

The code is mostly backwards compatible, unless you want to generate model builders. In this case you need to call three separate methods (because the old one had too many arguments, according to SonarCloud)