### PR TITLE
Builder validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Visual Studio code
+.vscode/

--- a/src/ModelFramework.CodeGeneration.Tests/CodeGenerationTests.cs
+++ b/src/ModelFramework.CodeGeneration.Tests/CodeGenerationTests.cs
@@ -245,7 +245,7 @@ namespace Test.Builders
             #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             #pragma warning restore CS8604 // Possible null reference argument.
             var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance, null, null), results, true);
+            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, validationContext, results, true);
             return results;
         }
 

--- a/src/ModelFramework.Generators.Objects.Tests/CSharpClassGeneratorTests.cs
+++ b/src/ModelFramework.Generators.Objects.Tests/CSharpClassGeneratorTests.cs
@@ -3632,7 +3632,7 @@ namespace MyNamespace
         {
             var instance = new MyNamespace.MyRecordBase(Property1);
             var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance, null, null), results, true);
+            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, validationContext, results, true);
             return results;
         }
 
@@ -3772,7 +3772,7 @@ namespace MyNamespace
         {
             var instance = new MyNamespace.MyRecordBase();
             var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance, null, null), results, true);
+            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, validationContext, results, true);
             return results;
         }
 
@@ -3853,7 +3853,7 @@ namespace MyNamespace
             #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             #pragma warning restore CS8604 // Possible null reference argument.
             var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance, null, null), results, true);
+            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, validationContext, results, true);
             return results;
         }
 
@@ -3946,7 +3946,7 @@ namespace Models
             #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
             #pragma warning restore CS8604 // Possible null reference argument.
             var results = new System.Collections.Generic.List<System.ComponentModel.DataAnnotations.ValidationResult>();
-            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, new System.ComponentModel.DataAnnotations.ValidationContext(instance, null, null), results, true);
+            System.ComponentModel.DataAnnotations.Validator.TryValidateObject(instance, validationContext, results, true);
             return results;
         }
 

--- a/src/ModelFramework.Objects/Extensions/TypeBaseExtensions.ImmutableBuilderClassBuilder.cs
+++ b/src/ModelFramework.Objects/Extensions/TypeBaseExtensions.ImmutableBuilderClassBuilder.cs
@@ -482,7 +482,7 @@ public static partial class TypeBaseEtensions
             .AddLiteralCodeStatements
             (
                 $"var results = new {typeof(List<>).WithoutGenerics()}<{typeof(ValidationResult).FullName}>();",
-                $"{typeof(Validator).FullName}.{nameof(Validator.TryValidateObject)}(instance, new {typeof(ValidationContext).FullName}(instance, null, null), results, true);",
+                $"{typeof(Validator).FullName}.{nameof(Validator.TryValidateObject)}(instance, validationContext, results, true);",
                 "return results;"
             );
 


### PR DESCRIPTION
Validation method of generated builder classes ignore the supplied validationContext argument, but create a new validation context instead. This is wrong.